### PR TITLE
Return 400 if params is not present

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -7,7 +7,7 @@ class CharactersController < ApplicationController
   # 必須パラメータ name:string
   def search
     if params[:name].blank?
-      render json: [{"error": "100", "msg": "必須パラメーターがありません", "required": {"key": "name"}}]
+      render status: 400,  json: [{"error": "100", "msg": "必須パラメーターがありません", "required": {"key": "name"}}]
     else 
       tmp = Character.where("name like ?", "%" + params[:name] + "%")
       tmp += Character.where("phonetic like ?", "%" + params[:name] + "%")

--- a/test/controllers/characters_controller_test.rb
+++ b/test/controllers/characters_controller_test.rb
@@ -13,7 +13,7 @@ class CharactersControllerTest < ActionDispatch::IntegrationTest
 
   test "return error message when get search without required params" do
     get characters_search_url, as: :json
-    assert_response :success
+    assert_response :bad_request
     assert_match /error/, @response.body
   end
 end


### PR DESCRIPTION
paramsがないときは400を返し、異常系であることをわかりやすくした。